### PR TITLE
fix(build): Add missing database dependency and exclude test directories

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,7 @@
     "test": "jest --passWithNoTests --testPathIgnorePatterns=test/"
   },
   "dependencies": {
+    "@codequal/database": "^0.1.0",
     "@kubernetes/client-node": "^1.3.0",
     "@supabase/supabase-js": "^2.50.0",
     "@types/node-cron": "^3.0.11",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,19 +1,29 @@
 {
-    "extends": "../../tsconfig.json",
-    "compilerOptions": {
-      "outDir": "./dist",
-      "rootDir": "./src",
-      "composite": true,
-      "declaration": true,
-      "paths": {
-        "@codequal/core/*": ["./src/*"]
-      },
-      "skipLibCheck": true,
-      "resolveJsonModule": true,
-      "allowSyntheticDefaultImports": true,
-      "isolatedModules": true,
-      "noEmitOnError": false
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "composite": true,
+    "declaration": true,
+    "paths": {
+      "@codequal/core/*": [
+        "./src/*"
+      ]
     },
-    "include": ["src/**/*"],
-    "exclude": ["node_modules", "dist", "**/*.test.ts"]
-  }
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "noEmitOnError": false
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/tests/**",
+    "**/__tests__/**"
+  ]
+}


### PR DESCRIPTION
- Added @codequal/database as dependency to @codequal/core package.json
- Updated tsconfig.json to exclude tests/ and __tests__/ directories from build
- Fixes CI build error: Cannot find module '@codequal/database'